### PR TITLE
Inital fork of original repo /mniedermaier/CybICS. 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "software/OpenPLC/OpenPLC_v3"]
 	path = software/OpenPLC/OpenPLC_v3
-	url = ../OpenPLC_v3
+	url = git://github.com/mniedermaier/OpenPLC_v3.git


### PR DESCRIPTION
Update of .gitmodules and .git/config so submodule software/OpenPLC/OpenPLC_v3 still points to /mniedermaier/OpenPLC_v3/tree/18639c4996eaaa1eaa8af21425d9d46c7adc08c5